### PR TITLE
Fix thunder repo url in composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -40,7 +40,7 @@
         },
         "thunder": {
             "type": "git",
-            "url": "git@github.com/BurdaMagazinOrg/thunder-distribution.git"
+            "url": "git@github.com:BurdaMagazinOrg/thunder-distribution.git"
         },
         "paragraphs_features": {
             "type": "git",


### PR DESCRIPTION
I get following error:
```
Failed to execute git clone --mirror 'git@github.com/BurdaMagazinOrg/thunder-distribution.git' 

fatal: repository 'git@github.com/BurdaMagazinOrg/thunder-distribution.git' does not exist
```