### PR TITLE
Proposal for default ddev configurations

### DIFF
--- a/.ddev/docker-compose.selenium.yaml
+++ b/.ddev/docker-compose.selenium.yaml
@@ -1,0 +1,21 @@
+version: '3'
+
+services:
+  selenium:
+    container_name: ddev-${DDEV_SITENAME}-selenium
+    # Currently we are using locked version of selenium on Travis CI, that's why it's locked also here.
+    image: selenium/standalone-chrome-debug:3.8.1-aluminum
+    volumes:
+      - ".:/mnt/ddev_config"
+    restart: "no"
+    links:
+      - web:$DDEV_HOSTNAME
+    ports:
+      - "4444"
+      - "6000:5900"
+    labels:
+      com.ddev.site-name: ${DDEV_SITENAME}
+      com.ddev.platform: ddev
+      com.ddev.app-type: drupal8
+      com.ddev.approot: $DDEV_APPROOT
+      com.ddev.app-url: $DDEV_URL

--- a/.ddev/nginx-site.conf
+++ b/.ddev/nginx-site.conf
@@ -1,0 +1,113 @@
+# ddev drupal8 config
+
+# You can override ddev's configuration by placing an edited copy
+# of this config (or one of the other ones) in .ddev/nginx-site.conf
+# See https://ddev.readthedocs.io/en/latest/users/extend/customization-extendibility/#providing-custom-nginx-configuration
+
+# Set https to 'on' if x-forwarded-proto is https
+map $http_x_forwarded_proto $fcgi_https {
+    default off;
+    https on;
+}
+
+server {
+    listen 80; ## listen for ipv4; this line is default and implied
+    listen [::]:80 default ipv6only=on; ## listen for ipv6
+    # The NGINX_DOCROOT variable is substituted with
+    # its value when the container is started.
+    root $NGINX_DOCROOT;
+    index index.php index.htm index.html;
+
+    # Make site accessible from http://localhost/
+    server_name _;
+
+    # Disable sendfile as per https://docs.vagrantup.com/v2/synced-folders/virtualbox.html
+    sendfile off;
+    error_log /var/log/nginx/error.log info;
+    access_log /var/log/nginx/error.log;
+
+    location / {
+        try_files $uri /index.php?$query_string; # For Drupal >= 7
+    }
+
+    location @rewrite {
+        # For D7 and above:
+        # Clean URLs are handled in drupal_environment_initialize().
+        rewrite ^ /index.php;
+    }
+
+    # Handle image styles for Drupal 7+
+    location ~ ^/sites/.*/files/styles/ {
+        try_files $uri @rewrite;
+    }
+
+    # pass the PHP scripts to FastCGI server listening on socket
+    location ~ \.php$ {
+        try_files $uri =404;
+        fastcgi_split_path_info ^(.+\.php)(/.+)$;
+        fastcgi_pass unix:/run/php-fpm.sock;
+        fastcgi_buffers 16 128k;
+        fastcgi_buffer_size 512k;
+        fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
+        fastcgi_param SCRIPT_NAME $fastcgi_script_name;
+        fastcgi_index index.php;
+        include fastcgi_params;
+        fastcgi_intercept_errors on;
+        # fastcgi_read_timeout should match max_execution_time in php.ini
+        fastcgi_read_timeout 360;
+        fastcgi_param SERVER_NAME $host;
+        fastcgi_param HTTPS $fcgi_https;
+    }
+
+    # Expire rules for static content
+    # Feed
+    location ~* \.(?:rss|atom)$ {
+        expires 1h;
+    }
+
+    # Media: images, icons, video, audio, HTC
+    location ~* \.(?:jpg|jpeg|gif|png|ico|cur|gz|svg|svgz|mp4|ogg|ogv|webm|htc)$ {
+        expires 1M;
+        access_log off;
+        add_header Cache-Control "public";
+    }
+
+    # Prevent clients from accessing hidden files (starting with a dot)
+    # This is particularly important if you store .htpasswd files in the site hierarchy
+    # Access to `/.well-known/` is allowed.
+    # https://www.mnot.net/blog/2010/04/07/well-known
+    # https://tools.ietf.org/html/rfc5785
+    location ~* /\.(?!well-known\/) {
+        deny all;
+    }
+
+    # Prevent clients from accessing to backup/config/source files
+    location ~* (?:\.(?:bak|conf|dist|fla|in[ci]|log|psd|sh|sql|sw[op])|~)$ {
+        deny all;
+    }
+
+    ## Regular private file serving (i.e. handled by Drupal).
+    location ^~ /system/files/ {
+        ## For not signaling a 404 in the error log whenever the
+        ## system/files directory is accessed add the line below.
+        ## Note that the 404 is the intended behavior.
+        log_not_found off;
+        access_log off;
+        expires 30d;
+        try_files $uri @rewrite;
+    }
+
+    ## provide a health check endpoint
+    location /healthcheck {
+        access_log off;
+        stub_status     on;
+        keepalive_timeout 0;    # Disable HTTP keepalive
+        return 200;
+    }
+
+    error_page 400 401 /40x.html;
+    location = /40x.html {
+            root   /usr/share/nginx/html;
+    }
+
+}

--- a/.ddev/nginx-site.conf
+++ b/.ddev/nginx-site.conf
@@ -24,9 +24,10 @@ server {
     # Disable sendfile as per https://docs.vagrantup.com/v2/synced-folders/virtualbox.html
     sendfile off;
     error_log /var/log/nginx/error.log info;
-    access_log /var/log/nginx/error.log;
+    access_log /var/log/nginx/access.log;
 
     location / {
+        absolute_redirect off;
         try_files $uri /index.php?$query_string; # For Drupal >= 7
     }
 
@@ -108,6 +109,18 @@ server {
     error_page 400 401 /40x.html;
     location = /40x.html {
             root   /usr/share/nginx/html;
+    }
+
+    location ~ ^/(fpmstatus|ping)$ {
+         access_log off;
+         stub_status     on;
+         keepalive_timeout 0;    # Disable HTTP keepalive
+         allow 127.0.0.1;
+         allow all;
+         fastcgi_index index.php;
+         fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
+         include fastcgi_params;
+         fastcgi_pass unix:/run/php-fpm.sock;
     }
 
 }

--- a/.ddev/php/20-xdebug.ini
+++ b/.ddev/php/20-xdebug.ini
@@ -1,0 +1,5 @@
+zend_extension=xdebug.so
+xdebug.remote_enable=0
+xdebug.remote_host=172.28.99.99
+xdebug.remote_port=11011
+xdebug.max_nesting_level=512

--- a/.ddev/php/20-xdebug.ini
+++ b/.ddev/php/20-xdebug.ini
@@ -1,5 +1,5 @@
-zend_extension=xdebug.so
-xdebug.remote_enable=0
-xdebug.remote_host=172.28.99.99
-xdebug.remote_port=11011
-xdebug.max_nesting_level=512
+; zend_extension=xdebug.so
+; xdebug.remote_enable=1
+; xdebug.remote_host=172.28.99.99
+; xdebug.remote_port=11011
+; xdebug.max_nesting_level=512

--- a/.ddev/php/20-xdebug.ini
+++ b/.ddev/php/20-xdebug.ini
@@ -1,5 +1,5 @@
-; zend_extension=xdebug.so
-; xdebug.remote_enable=1
-; xdebug.remote_host=172.28.99.99
-; xdebug.remote_port=11011
-; xdebug.max_nesting_level=512
+;zend_extension=xdebug.so
+;xdebug.remote_enable=1
+;xdebug.remote_host=docker.for.mac.host.internal
+;xdebug.remote_port=9000
+;xdebug.max_nesting_level=512

--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,7 @@ composer.lock
 .idea
 .DS_Store
 
+# Additional ddev files that should not be versioned
+.ddev/config.yaml
+.ddev/docker-compose.yaml
+

--- a/README.md
+++ b/README.md
@@ -20,5 +20,13 @@ folder.
     git checkout -b feature/new-thunder-feature # <-- this will be a branch in the distribution not the project
     <make changes>
     git commit .
-    
 
+### Running tests for Thunder Distribution with `ddev`
+
+To run tests for distribution Selenium docker container is required. That's provided with `docker-compose.selenium.yaml`.
+Tests has to be executed inside `web` container, that's why it's required to ssh inside with `ddev ssh`.
+After that global environment variable should be set:
+```export THUNDER_WEBDRIVER_HOST="selenium:4444"```
+with that environment for executing tests is set.
+
+Tests can be run like this: `php core/scripts/run-tests.sh --url http://thunder.ddev.local --verbose Thunder`


### PR DESCRIPTION
Here is proposal for default ddev configurations:

1. Selenium docker composer file is added and when ddev is started it will run up also selenium what can be used for executing distribution tests
2. `nginx-site.conf` has problem with running of Drupal tests, since Drupal returns big header what can't be handled with nginx. So config has to be adjusted to increase buff sizes. **This should be compared with default config** - since I played a lot with config file and at end only following is relevant.
```
        fastcgi_buffers 16 128k;
        fastcgi_buffer_size 512k;
```
3. X-Debug turned off by default and also config - it allows easy turn on/off - with `ddev restart` after change.

That should be it.